### PR TITLE
updated deleteTask to include associated Tascam and Memo objects from…

### DIFF
--- a/src/components/Task.js
+++ b/src/components/Task.js
@@ -69,7 +69,7 @@ export default function Task({ ...rest }) {
         <Button color='dark' onClick={() => {
           // eslint-disable-next-line no-alert
           if (window.confirm('delete...?')) {
-            deleteTask(rest.task.firebaseKey, rest.user.uid).then(rest.setTasks);
+            deleteTask(rest.task.firebaseKey, tascam[0].firebaseKey, memo1.firebaseKey, memo2.firebaseKey, memo3.firebaseKey, rest.user.uid).then(rest.setTasks);
           }
         }
         }><img alt='delete button' src={images.xIcon}

--- a/src/helpers/data/TaskData.js
+++ b/src/helpers/data/TaskData.js
@@ -19,13 +19,6 @@ const addTask = (taskObj) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
-// original, working updateTask just in case
-// const updateTask = (taskObj) => new Promise((resolve, reject) => {
-//   axios.patch(`${dbUrl}/task/${taskObj.firebaseKey}.json`, taskObj)
-//     .then(() => getTasks(taskObj.uid).then(resolve))
-//     .catch((error) => reject(error));
-// });
-
 // updateTask updates all tables associated to the respective task (tascam, memo)
 const updateTask = (taskObj, memo1Obj, memo2Obj, memo3Obj, tascamObj) => new Promise((resolve, reject) => {
   // patch each table object
@@ -40,8 +33,13 @@ const updateTask = (taskObj, memo1Obj, memo2Obj, memo3Obj, tascamObj) => new Pro
     .catch((error) => reject(error));
 });
 
-const deleteTask = (firebaseKey, uid) => new Promise((resolve, reject) => {
-  axios.delete(`${dbUrl}/task/${firebaseKey}.json`)
+const deleteTask = (taskFbKey, tascamFbKey, memo1FbKey, memo2FbKey, memo3FbKey, uid) => new Promise((resolve, reject) => {
+  const deleteTaskObj = axios.delete(`${dbUrl}/task/${taskFbKey}.json`);
+  const deleteTascam = axios.delete(`${dbUrl}/tascam/${tascamFbKey}.json`);
+  const deleteMemo1 = axios.delete(`${dbUrl}/memo/${memo1FbKey}.json`);
+  const deleteMemo2 = axios.delete(`${dbUrl}/memo/${memo2FbKey}.json`);
+  const deleteMemo3 = axios.delete(`${dbUrl}/memo/${memo3FbKey}.json`);
+  Promise.all([deleteTaskObj, deleteTascam, deleteMemo1, deleteMemo2, deleteMemo3])
     .then(() => getTasks(uid).then(resolve))
     .catch((error) => reject(error));
 });


### PR DESCRIPTION
… their tables as well when you delete the Task. easy peasey.

## Description

oh yeah! deleteTask now deletes associated Tascam and Memo objects from their tables

## Related Issue

#6, now complete

## Motivation and Context

Enabled full CRUD for the Tascam and Memo tables (update and delete here)

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
