### PR TITLE
sorted resp before setting Tasks, thus sorting them from newest to ol…

### DIFF
--- a/src/App/index.js
+++ b/src/App/index.js
@@ -22,7 +22,10 @@ function App() {
           uid: authed.uid
         };
         setUser(userInfoObj);
-        getTasks(userInfoObj.uid).then(setTasks);
+        getTasks(userInfoObj.uid).then((resp) => {
+          resp.sort((a, b) => ((a.day < b.day) ? 1 : -1));
+          setTasks(resp);
+        });
       } else if (user || user === null) {
         setUser(false);
       }


### PR DESCRIPTION
## Description

added logic to sort response before setting Tasks, thus sorting tasks from newest to oldest

## Related Issue

#16 

## Motivation and Context

So user has intuitive experience: seeing newest tasks first

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
